### PR TITLE
MYFOODRX-49 Fix Serving size on generated recipes thumbnail

### DIFF
--- a/lib/features/education/views/article_detail_page.dart
+++ b/lib/features/education/views/article_detail_page.dart
@@ -28,7 +28,6 @@ class ArticleDetailPage extends StatelessWidget {
           body: CustomScrollView(
             slivers: [
               SliverAppBar(
-                expandedHeight: 240.0,
                 pinned: true,
                 backgroundColor: Colors.white,
                 elevation: 0,
@@ -52,8 +51,12 @@ class ArticleDetailPage extends StatelessWidget {
                     },
                   ),
                 ],
-                flexibleSpace: FlexibleSpaceBar(
-                  background: Image(
+              ),
+              SliverToBoxAdapter(
+                child: SizedBox(
+                  height: 240.0,
+                  width: double.infinity,
+                  child: Image(
                     image: ImageCacheService()
                         .getImageProvider(latestArticle.imageUrl),
                     width: double.infinity,

--- a/lib/features/recipes/views/recipe_detail_page.dart
+++ b/lib/features/recipes/views/recipe_detail_page.dart
@@ -337,6 +337,12 @@ class _RecipeDetailPageState extends State<RecipeDetailPage> {
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: _buildCookButton(),
+        ),
+      ),
       body: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -350,8 +356,6 @@ class _RecipeDetailPageState extends State<RecipeDetailPage> {
                   _buildTitleSection(context),
                   const SizedBox(height: 16),
                   _buildIngredientTags(),
-                  const SizedBox(height: 16),
-                  _buildCookButton(),
                   const SizedBox(height: 24),
                   _buildSectionTitle(
                       'Ingredients for ${_adjustedRecipe.servings} servings'),
@@ -402,7 +406,7 @@ class _RecipeDetailPageState extends State<RecipeDetailPage> {
                   ),
                   SizedBox(width: 12),
                   Text(
-                    'Cooking...',
+                    'Processing...',
                     style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                   ),
                 ],
@@ -410,12 +414,12 @@ class _RecipeDetailPageState extends State<RecipeDetailPage> {
             : const Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.restaurant, size: 20),
-                  SizedBox(width: 8),
                   Text(
-                    'Cook This Recipe',
+                    'I Cooked This',
                     style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                   ),
+                  SizedBox(width: 8),
+                  Icon(Icons.restaurant, size: 20),
                 ],
               ),
       ),
@@ -469,19 +473,6 @@ class _RecipeDetailPageState extends State<RecipeDetailPage> {
                 style:
                     const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
               ),
-              if (widget.targetServings != null &&
-                  widget.targetServings != widget.recipe.servings)
-                Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: Text(
-                    'Scaled from ${widget.recipe.servings} to ${widget.targetServings} servings',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: Colors.grey[600],
-                      fontStyle: FontStyle.italic,
-                    ),
-                  ),
-                ),
             ],
           ),
         ),

--- a/lib/features/recipes/widgets/recipe_card.dart
+++ b/lib/features/recipes/widgets/recipe_card.dart
@@ -34,7 +34,8 @@ class RecipeCard extends StatelessWidget {
               recipe: recipe,
               // When coming from saved recipes, show original servings
               // When coming from generated recipes, use user's preferred servings
-              targetServings: fromSaved ? null : controller.currentFilter.servings,
+              targetServings:
+                  fromSaved ? null : controller.currentFilter.servings,
             ),
           ),
         );
@@ -61,31 +62,8 @@ class RecipeCard extends StatelessWidget {
                   imageUrl: recipe.image,
                   height: 200,
                   width: double.infinity,
-                  borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
-                ),
-                Positioned(
-                  top: 10,
-                  left: 10,
-                  child: Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-                    decoration: BoxDecoration(
-                      color: Colors.black.withOpacity(0.6),
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: Row(
-                      children: [
-                        const Icon(Icons.people_outline,
-                            color: Colors.white, size: 16),
-                        const SizedBox(width: 6),
-                        Text(
-                          '${recipe.servings} Servings',
-                          style: const TextStyle(
-                              color: Colors.white, fontSize: 12),
-                        ),
-                      ],
-                    ),
-                  ),
+                  borderRadius:
+                      const BorderRadius.vertical(top: Radius.circular(12)),
                 ),
                 Positioned(
                   bottom: 10,


### PR DESCRIPTION
### Summary

- Remove Serving sizes from Recipe Thumbnails
- Updated button text from 'Cook This Recipe' to 'I Cooked This' for better clarity
- Refactor ArticleDetailPage layout by replacing SliverAppBar's expandedHeight with a SliverToBoxAdapter containing a SizedBox for the article image. This change enhances the layout structure and maintains the visual integrity of the article detail view

