### PR TITLE
Add Forget Password Support (#57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ dialogflow_auth.json
 
 #feature prd
 /feature_prd
+
+#migrate db
+/migrate-db

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,22 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Deep link intent filter for password reset -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data 
+                    android:scheme="foodrx"
+                    android:host="reset-password"/>
+            </intent-filter>
+            <!-- Also handle foodrx:// links without host -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="foodrx"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - app_links (6.4.1):
+    - Flutter
   - Firebase/CoreOnly (10.25.0):
     - FirebaseCore (= 10.25.0)
   - Firebase/Messaging (10.25.0):
@@ -87,6 +89,7 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - app_links (from `.symlinks/plugins/app_links/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
@@ -111,6 +114,8 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
+  app_links:
+    :path: ".symlinks/plugins/app_links/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_messaging:
@@ -133,6 +138,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
+  app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   Firebase: 0312a2352584f782ea56f66d91606891d4607f06
   firebase_core: 3b49a055ff54114cae400581c13671fe53936c36
   firebase_messaging: 394589dcda43e42ec9807558a409a975e285c45b

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,5 +51,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.shield.myfoodrx</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>foodrx</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/lib/core/services/email_service.dart
+++ b/lib/core/services/email_service.dart
@@ -1,0 +1,17 @@
+/// Abstract interface for email services
+abstract class EmailService {
+  /// Send a password reset email to the user
+  /// 
+  /// [email] - Recipient email address
+  /// [resetToken] - The password reset token to include in the link
+  /// [userName] - Optional user name for personalization
+  /// 
+  /// Returns true if email was sent successfully, false otherwise
+  Future<bool> sendPasswordResetEmail({
+    required String email,
+    required String resetToken,
+    String? userName,
+  });
+}
+
+

--- a/lib/core/services/gmail_smtp_email_service.dart
+++ b/lib/core/services/gmail_smtp_email_service.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:mailer/mailer.dart';
+import 'package:mailer/smtp_server.dart';
+import 'package:flutter_app/core/services/email_service.dart';
+
+/// Gmail SMTP implementation of EmailService
+/// This is completely free, doesn't require a domain, and works server-side
+/// Requires Gmail app password setup (see EMAIL_SETUP.md)
+class GmailSMTPEmailService implements EmailService {
+  GmailSMTPEmailService();
+
+  @override
+  Future<bool> sendPasswordResetEmail({
+    required String email,
+    required String resetToken,
+    String? userName,
+  }) async {
+    try {
+      // Get Gmail credentials from environment
+      final gmailUser = dotenv.env['GMAIL_USER'];
+      final gmailPassword = dotenv.env['GMAIL_APP_PASSWORD'];
+
+      if (gmailUser == null || gmailUser.isEmpty) {
+        throw Exception('GMAIL_USER is missing in .env file. '
+            'Please add your Gmail address (e.g., yourname@gmail.com)');
+      }
+      if (gmailPassword == null || gmailPassword.isEmpty) {
+        throw Exception('GMAIL_APP_PASSWORD is missing in .env file. '
+            'Please generate an app password from your Google Account settings. '
+            'See EMAIL_SETUP.md for instructions.');
+      }
+
+      // Get the app URL from environment or use default deep link scheme
+      final appUrl = dotenv.env['APP_URL'] ?? 'foodrx://reset-password';
+      // URL encode the token to ensure it works in email links
+      final encodedToken = Uri.encodeComponent(resetToken);
+      final resetLink = '$appUrl?token=$encodedToken';
+
+      // Get sender name from environment
+      final fromName = dotenv.env['EMAIL_FROM_NAME'] ?? 'MyFoodRx';
+      final displayName = userName ?? 'User';
+
+      // Create Gmail SMTP server
+      final smtpServer = gmail(gmailUser, gmailPassword);
+
+      // Build email message
+      final message = Message()
+        ..from = Address(gmailUser, fromName)
+        ..recipients.add(email)
+        ..subject = 'Reset Your Password - MyFoodRx'
+        ..html = _buildPasswordResetEmailBody(displayName, resetLink);
+
+      // Send email
+      try {
+        final sendReport = await send(message, smtpServer);
+        return sendReport.toString().contains('Message successfully sent');
+      } catch (e) {
+        // Check for specific Gmail errors
+        if (e.toString().contains('535') ||
+            e.toString().contains('authentication')) {
+          throw Exception(
+              'Gmail authentication failed. Please check your GMAIL_APP_PASSWORD. '
+              'Make sure you\'re using an App Password, not your regular Gmail password. '
+              'See EMAIL_SETUP.md for setup instructions.');
+        }
+        rethrow;
+      }
+    } catch (e) {
+      throw Exception('Failed to send password reset email: $e');
+    }
+  }
+
+  String _buildPasswordResetEmailBody(String userName, String resetLink) {
+    return '''
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset Your Password</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f7f7f8;">
+  <table role="presentation" style="width: 100%; border-collapse: collapse;">
+    <tr>
+      <td style="padding: 40px 20px; text-align: center;">
+        <table role="presentation" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 12px; padding: 40px;">
+          <tr>
+            <td style="text-align: center; padding-bottom: 30px;">
+              <h1 style="color: #2C2C2C; font-size: 24px; margin: 0; font-weight: bold;">Reset Your Password</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-bottom: 20px;">
+              <p style="color: #545454; font-size: 16px; line-height: 1.6; margin: 0;">
+                Hello $userName,
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-bottom: 30px;">
+              <p style="color: #545454; font-size: 16px; line-height: 1.6; margin: 0;">
+                We received a request to reset your password. Click the button below to create a new password:
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-bottom: 20px; text-align: center;">
+              <a href="$resetLink" 
+                 style="display: inline-block; background-color: #FF6A00; color: #ffffff !important; text-decoration: none !important; padding: 14px 32px; border-radius: 24px; font-size: 16px; font-weight: 600;">
+                Reset Password
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-bottom: 20px;">
+              <p style="color: #90909A; font-size: 14px; line-height: 1.6; margin: 0 0 10px 0;">
+                <strong>Note:</strong> If the button above doesn't work, copy the link below and paste it into your mobile browser (Chrome, Safari, etc.):
+              </p>
+              <div style="background-color: #F7F7F8; padding: 12px; border-radius: 8px; margin: 10px 0;">
+                <p style="color: #2C2C2C; font-size: 13px; line-height: 1.6; margin: 0; word-break: break-all; font-family: monospace;">
+                  $resetLink
+                </p>
+              </div>
+              <p style="color: #90909A; font-size: 12px; line-height: 1.6; margin: 10px 0 0 0;">
+                After pasting in your browser, tap the link and your MyFoodRx app will open automatically.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-top: 30px; border-top: 1px solid #E7E9EC;">
+              <p style="color: #90909A; font-size: 12px; line-height: 1.6; margin: 0;">
+                <strong>Security Notice:</strong> This link will expire in 1 hour. If you didn't request a password reset, please ignore this email or contact support if you have concerns.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-top: 20px;">
+              <p style="color: #90909A; font-size: 12px; line-height: 1.6; margin: 0;">
+                Best regards,<br>
+                MyFoodRx Team
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+''';
+  }
+}

--- a/lib/features/auth/views/forgot_password_page.dart
+++ b/lib/features/auth/views/forgot_password_page.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/features/auth/controller/auth_controller.dart';
+import 'package:flutter_app/core/widgets/form_fields.dart';
+import 'package:flutter_app/core/utils/typography.dart';
+import 'package:provider/provider.dart';
+
+class ForgotPasswordPage extends StatefulWidget {
+  const ForgotPasswordPage({super.key});
+
+  @override
+  State<ForgotPasswordPage> createState() => _ForgotPasswordPageState();
+}
+
+class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _emailFocusNode = FocusNode();
+  bool _isLoading = false;
+  bool _emailSent = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _emailFocusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleRequestReset() async {
+    // Dismiss keyboard
+    FocusScope.of(context).unfocus();
+
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final authController = context.read<AuthController>();
+      final success = await authController.requestPasswordReset(
+        _emailController.text.trim(),
+      );
+
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        if (success) {
+          _emailSent = true;
+        } else {
+          _errorMessage = authController.error ?? 'Failed to send reset email';
+        }
+      });
+
+      if (!success && _errorMessage != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_errorMessage!),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _errorMessage = 'An error occurred: $e';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(_errorMessage!),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      // Dismiss keyboard when tapping outside
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF7F7F8),
+        appBar: AppBar(
+          backgroundColor: const Color(0xFFF7F7F8),
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Color(0xFF2C2C2C)),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        body: SingleChildScrollView(
+          // Enable scrolling when keyboard appears
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+          child: Form(
+            key: _formKey,
+            child: Container(
+              padding: const EdgeInsets.all(16),
+              margin: const EdgeInsets.only(left: 16.0, right: 16.0, top: 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Forgot Password?', style: AppTypography.bg_24_b),
+                  const SizedBox(height: 8),
+                  Text(
+                    _emailSent
+                        ? 'We\'ve sent a password reset link to your email address. Please check your inbox and follow the instructions to reset your password.'
+                        : 'Enter your email address and we\'ll send you a link to reset your password.',
+                    style: AppTypography.bg_14_r
+                        .copyWith(color: const Color(0xFF90909A)),
+                  ),
+                  if (!_emailSent) ...[
+                    const SizedBox(height: 40),
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 16),
+                      margin: const EdgeInsets.only(bottom: 20),
+                      decoration: ShapeDecoration(
+                        color: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          AppFormField(
+                            label: 'Email',
+                            hintText: 'Enter your email',
+                            controller: _emailController,
+                            focusNode: _emailFocusNode,
+                            keyboardType: TextInputType.emailAddress,
+                            textInputAction: TextInputAction.done,
+                            onFieldSubmitted: (_) => _handleRequestReset(),
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return 'Please enter your email';
+                              }
+                              if (!value.contains('@')) {
+                                return 'Please enter a valid email';
+                              }
+                              return null;
+                            },
+                          ),
+                          if (_errorMessage != null) ...[
+                            const SizedBox(height: 8),
+                            Container(
+                              width: double.infinity,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 8, vertical: 4),
+                              child: Text(
+                                _errorMessage!,
+                                style: const TextStyle(
+                                  color: Colors.red,
+                                  fontSize: 12,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 48,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFFF6A00),
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(24),
+                          ),
+                          elevation: 0,
+                        ),
+                        onPressed: _isLoading ? null : _handleRequestReset,
+                        child: _isLoading
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  color: Colors.white,
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Send Reset Link',
+                                style: AppTypography.bg_16_sb),
+                      ),
+                    ),
+                  ] else ...[
+                    const SizedBox(height: 40),
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(24),
+                      decoration: ShapeDecoration(
+                        color: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: Column(
+                        children: [
+                          const Icon(
+                            Icons.check_circle_outline,
+                            color: Color(0xFF4CAF50),
+                            size: 64,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            'Email Sent!',
+                            style: AppTypography.bg_18_b,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'Please check your email inbox and follow the instructions to reset your password.',
+                            style: AppTypography.bg_14_r.copyWith(
+                              color: const Color(0xFF90909A),
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 48,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFFF6A00),
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(24),
+                          ),
+                          elevation: 0,
+                        ),
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('Back to Login',
+                            style: AppTypography.bg_16_sb),
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 20),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/auth/views/login_page.dart
+++ b/lib/features/auth/views/login_page.dart
@@ -52,6 +52,10 @@ class _LoginPageState extends State<LoginPage> {
       return;
     }
 
+    // Store credentials before clearing
+    final email = _emailController.text.trim();
+    final password = _passwordController.text;
+
     if (!mounted) return;
     setState(() {
       _isLoading = true;
@@ -61,8 +65,8 @@ class _LoginPageState extends State<LoginPage> {
     try {
       final authController = context.read<AuthController>();
       final success = await authController.login(
-        _emailController.text.trim(),
-        _passwordController.text,
+        email,
+        password,
       );
 
       if (!mounted) return;
@@ -77,10 +81,19 @@ class _LoginPageState extends State<LoginPage> {
         // Clear the form
         _emailController.clear();
         _passwordController.clear();
-        // Pop back to home - MaterialApp's home Consumer will automatically
-        // show MainScreen when authController.isAuthenticated becomes true
+        // Wait a moment for auth state to update, then navigate
+        // MaterialApp's home Consumer will automatically show MainScreen
+        // when authController.isAuthenticated becomes true
         if (mounted) {
-          Navigator.of(context).popUntil((route) => route.isFirst);
+          // Use a small delay to ensure state is updated
+          await Future.delayed(const Duration(milliseconds: 100));
+          if (mounted) {
+            // Clear navigation stack and let the home Consumer handle the navigation
+            Navigator.of(context).pushNamedAndRemoveUntil(
+              '/home',
+              (route) => false,
+            );
+          }
         }
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -226,15 +239,21 @@ class _LoginPageState extends State<LoginPage> {
                           ),
                         ],
                         const SizedBox(height: 8),
-                        const Align(
+                        Align(
                           alignment: Alignment.centerRight,
-                          child: Text(
-                            'Forgot Password?',
-                            style: TextStyle(
-                              color: Color(0xFF545454),
-                              fontSize: 12,
-                              fontFamily: 'Bricolage Grotesque',
-                              fontWeight: FontWeight.w400,
+                          child: GestureDetector(
+                            onTap: () {
+                              FocusScope.of(context).unfocus();
+                              Navigator.pushNamed(context, '/forgot-password');
+                            },
+                            child: const Text(
+                              'Forgot Password?',
+                              style: TextStyle(
+                                color: Color(0xFF545454),
+                                fontSize: 12,
+                                fontFamily: 'Bricolage Grotesque',
+                                fontWeight: FontWeight.w400,
+                              ),
                             ),
                           ),
                         ),

--- a/lib/features/auth/views/reset_password_page.dart
+++ b/lib/features/auth/views/reset_password_page.dart
@@ -1,0 +1,542 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/features/auth/controller/auth_controller.dart';
+import 'package:flutter_app/core/widgets/form_fields.dart';
+import 'package:flutter_app/core/utils/typography.dart';
+import 'package:provider/provider.dart';
+
+class ResetPasswordPage extends StatefulWidget {
+  final String? token;
+
+  const ResetPasswordPage({super.key, this.token});
+
+  @override
+  State<ResetPasswordPage> createState() => _ResetPasswordPageState();
+}
+
+class _ResetPasswordPageState extends State<ResetPasswordPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  final _passwordFocusNode = FocusNode();
+  final _confirmPasswordFocusNode = FocusNode();
+  bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
+  bool _isLoading = false;
+  bool _isValidatingToken = true;
+  bool _tokenValid = false;
+  bool _passwordReset = false;
+  String? _errorMessage;
+  
+  // Password requirement checkers
+  bool _hasMinLength(String password) => password.length >= 8;
+  bool _hasUppercase(String password) => password.contains(RegExp(r'[A-Z]'));
+  bool _hasLowercase(String password) => password.contains(RegExp(r'[a-z]'));
+  bool _hasNumber(String password) => password.contains(RegExp(r'[0-9]'));
+  bool _hasSpecialChar(String password) =>
+      password.contains(RegExp(r'[!@#$%^&*(),.?":{}|<>]'));
+
+  @override
+  void initState() {
+    super.initState();
+    // Delay validation to avoid build phase issues
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _validateToken();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    _passwordFocusNode.dispose();
+    _confirmPasswordFocusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _validateToken() async {
+    if (widget.token == null || widget.token!.isEmpty) {
+      setState(() {
+        _isValidatingToken = false;
+        _tokenValid = false;
+        _errorMessage = 'Invalid reset link. Please request a new password reset.';
+      });
+      return;
+    }
+
+    try {
+      final authController = context.read<AuthController>();
+      final isValid = await authController.validatePasswordResetToken(widget.token!);
+
+      if (!mounted) return;
+      setState(() {
+        _isValidatingToken = false;
+        _tokenValid = isValid;
+        if (!isValid) {
+          _errorMessage = authController.error ?? 'This reset link is invalid or has expired. Please request a new password reset.';
+        }
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isValidatingToken = false;
+        _tokenValid = false;
+        _errorMessage = 'An error occurred while validating the reset link: $e';
+      });
+    }
+  }
+
+  Future<void> _handleResetPassword() async {
+    // Dismiss keyboard
+    FocusScope.of(context).unfocus();
+
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final authController = context.read<AuthController>();
+      final success = await authController.resetPassword(
+        widget.token!,
+        _passwordController.text,
+      );
+
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        if (success) {
+          _passwordReset = true;
+        } else {
+          _errorMessage = authController.error ?? 'Failed to reset password';
+        }
+      });
+
+      if (!success && _errorMessage != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_errorMessage!),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 3),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _errorMessage = 'An error occurred: $e';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(_errorMessage!),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        // Prevent back navigation to invalid deep link state
+        // Navigate to login instead
+        Navigator.of(context).pushNamedAndRemoveUntil(
+          '/login',
+          (route) => false,
+        );
+        return false;
+      },
+      child: GestureDetector(
+        // Dismiss keyboard when tapping outside
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Scaffold(
+        backgroundColor: const Color(0xFFF7F7F8),
+        appBar: AppBar(
+          backgroundColor: const Color(0xFFF7F7F8),
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Color(0xFF2C2C2C)),
+            onPressed: () {
+              // Navigate to login instead of just popping
+              // This prevents navigation stack issues
+              Navigator.of(context).pushNamedAndRemoveUntil(
+                '/login',
+                (route) => false,
+              );
+            },
+          ),
+        ),
+        body: SingleChildScrollView(
+          // Enable scrolling when keyboard appears
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+          child: Form(
+            key: _formKey,
+            child: Container(
+              padding: const EdgeInsets.all(16),
+              margin: const EdgeInsets.only(left: 16.0, right: 16.0, top: 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Reset Password', style: AppTypography.bg_24_b),
+                  const SizedBox(height: 8),
+                  if (_isValidatingToken) ...[
+                    const SizedBox(height: 40),
+                    const Center(
+                      child: CircularProgressIndicator(
+                        valueColor: AlwaysStoppedAnimation<Color>(Color(0xFFFF6A00)),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    const Center(
+                      child: Text(
+                        'Validating reset link...',
+                        style: AppTypography.bg_14_r,
+                      ),
+                    ),
+                  ] else if (!_tokenValid) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      _errorMessage ?? 'Invalid reset link',
+                      style: AppTypography.bg_14_r.copyWith(
+                        color: Colors.red,
+                      ),
+                    ),
+                    const SizedBox(height: 40),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 48,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFFF6A00),
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(24),
+                          ),
+                          elevation: 0,
+                        ),
+                        onPressed: () => Navigator.of(context).pushReplacementNamed('/forgot-password'),
+                        child: const Text('Request New Reset Link',
+                            style: AppTypography.bg_16_sb),
+                      ),
+                    ),
+                  ] else if (_passwordReset) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      'Your password has been successfully reset. You can now login with your new password.',
+                      style: AppTypography.bg_14_r
+                          .copyWith(color: const Color(0xFF90909A)),
+                    ),
+                    const SizedBox(height: 40),
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(24),
+                      decoration: ShapeDecoration(
+                        color: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: Column(
+                        children: [
+                          const Icon(
+                            Icons.check_circle_outline,
+                            color: Color(0xFF4CAF50),
+                            size: 64,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            'Password Reset!',
+                            style: AppTypography.bg_18_b,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'Your password has been successfully reset. You can now login with your new password.',
+                            style: AppTypography.bg_14_r.copyWith(
+                              color: const Color(0xFF90909A),
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 48,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFFF6A00),
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(24),
+                          ),
+                          elevation: 0,
+                        ),
+                        onPressed: () {
+                          // Clear navigation stack and go to login
+                          Navigator.of(context).pushNamedAndRemoveUntil(
+                            '/login',
+                            (route) => false,
+                          );
+                        },
+                        child: const Text('Go to Login',
+                            style: AppTypography.bg_16_sb),
+                      ),
+                    ),
+                  ] else ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      'Enter your new password below.',
+                      style: AppTypography.bg_14_r
+                          .copyWith(color: const Color(0xFF90909A)),
+                    ),
+                    const SizedBox(height: 40),
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 16),
+                      margin: const EdgeInsets.only(bottom: 20),
+                      decoration: ShapeDecoration(
+                        color: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          AppFormField(
+                            label: 'New Password',
+                            hintText: 'Enter your new password',
+                            controller: _passwordController,
+                            focusNode: _passwordFocusNode,
+                            obscureText: _obscurePassword,
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) {
+                              _passwordFocusNode.unfocus();
+                              FocusScope.of(context)
+                                  .requestFocus(_confirmPasswordFocusNode);
+                            },
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return 'Please enter your new password';
+                              }
+                              if (value.length < 8) {
+                                return 'Password must be at least 8 characters';
+                              }
+                              if (!value.contains(RegExp(r'[A-Z]'))) {
+                                return 'Password must contain at least one uppercase letter';
+                              }
+                              if (!value.contains(RegExp(r'[a-z]'))) {
+                                return 'Password must contain at least one lowercase letter';
+                              }
+                              if (!value.contains(RegExp(r'[0-9]'))) {
+                                return 'Password must contain at least one number';
+                              }
+                              if (!value.contains(RegExp(r'[!@#$%^&*(),.?":{}|<>]'))) {
+                                return 'Password must contain at least one special character';
+                              }
+                              return null;
+                            },
+                            suffixIcon: IconButton(
+                              icon: Icon(
+                                _obscurePassword
+                                    ? Icons.visibility_off
+                                    : Icons.visibility,
+                                color: const Color(0xFF90909A),
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  _obscurePassword = !_obscurePassword;
+                                });
+                              },
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          ValueListenableBuilder<TextEditingValue>(
+                            valueListenable: _passwordController,
+                            builder: (context, value, child) {
+                              return _buildPasswordRequirements();
+                            },
+                          ),
+                          const SizedBox(height: 20),
+                          AppFormField(
+                            label: 'Confirm Password',
+                            hintText: 'Confirm your new password',
+                            controller: _confirmPasswordController,
+                            focusNode: _confirmPasswordFocusNode,
+                            obscureText: _obscureConfirmPassword,
+                            textInputAction: TextInputAction.done,
+                            onFieldSubmitted: (_) => _handleResetPassword(),
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return 'Please confirm your password';
+                              }
+                              if (value != _passwordController.text) {
+                                return 'Passwords do not match';
+                              }
+                              return null;
+                            },
+                            suffixIcon: IconButton(
+                              icon: Icon(
+                                _obscureConfirmPassword
+                                    ? Icons.visibility_off
+                                    : Icons.visibility,
+                                color: const Color(0xFF90909A),
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  _obscureConfirmPassword =
+                                      !_obscureConfirmPassword;
+                                });
+                              },
+                            ),
+                          ),
+                          if (_errorMessage != null) ...[
+                            const SizedBox(height: 8),
+                            Container(
+                              width: double.infinity,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 8, vertical: 4),
+                              child: Text(
+                                _errorMessage!,
+                                style: const TextStyle(
+                                  color: Colors.red,
+                                  fontSize: 12,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 48,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFFF6A00),
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(24),
+                          ),
+                          elevation: 0,
+                        ),
+                        onPressed: _isLoading ? null : _handleResetPassword,
+                        child: _isLoading
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  color: Colors.white,
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('Reset Password',
+                                style: AppTypography.bg_16_sb),
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 20),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+      ),
+    );
+  }
+
+  Widget _buildPasswordRequirements() {
+    final password = _passwordController.text;
+    final requirements = [
+      {
+        'text': 'At least 8 characters',
+        'met': _hasMinLength(password),
+      },
+      {
+        'text': 'One uppercase letter',
+        'met': _hasUppercase(password),
+      },
+      {
+        'text': 'One lowercase letter',
+        'met': _hasLowercase(password),
+      },
+      {
+        'text': 'One number',
+        'met': _hasNumber(password),
+      },
+      {
+        'text': 'One special character',
+        'met': _hasSpecialChar(password),
+      },
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF7F7F8),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Password must contain:',
+            style: TextStyle(
+              fontSize: 12,
+              fontFamily: 'BricolageGrotesque',
+              color: const Color(0xFF8E8E93),
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...requirements.map((req) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  children: [
+                    Icon(
+                      req['met'] as bool
+                          ? Icons.check_circle
+                          : Icons.circle_outlined,
+                      size: 16,
+                      color: req['met'] as bool
+                          ? const Color(0xFF34C759)
+                          : const Color(0xFFC7C7CC),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        req['text'] as String,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontFamily: 'BricolageGrotesque',
+                          color: req['met'] as bool
+                              ? const Color(0xFF34C759)
+                              : const Color(0xFF8E8E93),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/education/views/education_page.dart
+++ b/lib/features/education/views/education_page.dart
@@ -340,7 +340,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     bool overlapsContent,
   ) {
     return SizedBox(
-      height: 52.0,
+      height: maxExtent,
       child: Container(
         color: const Color(0xFFF7F7F8),
         child: Padding(

--- a/lib/features/home/views/home_page.dart
+++ b/lib/features/home/views/home_page.dart
@@ -626,7 +626,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                 Provider.of<TrackerProvider>(context, listen: false);
             final authProvider =
                 Provider.of<AuthController>(context, listen: false);
-            final user = authProvider.currentUser;
+            var user = authProvider.currentUser;
 
             // Clear trackers and cache first
             trackerProvider.clearTrackers();
@@ -637,10 +637,15 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
 
               // Wait a moment to ensure cache is cleared
               await Future.delayed(const Duration(milliseconds: 100));
+
+              // Re-fetch user after delay to ensure it's still valid (user might have logged out)
+              if (mounted && !_isDisposed) {
+                user = authProvider.currentUser;
+              }
             }
 
             // Reload with new diet type and plan (force reload)
-            if (mounted && !_isDisposed) {
+            if (mounted && !_isDisposed && user?.id != null) {
               final personalizedDietPlan = user?.selectedDietPlan;
               final dietType =
                   _mapMyPlanTypeToDietType(user?.myPlanType ?? user?.dietType);

--- a/lib/features/profile/views/profile_page.dart
+++ b/lib/features/profile/views/profile_page.dart
@@ -276,7 +276,11 @@ class _ProfilePageState extends State<ProfilePage> {
       final authController = context.read<AuthController>();
       await authController.logout();
       if (context.mounted) {
-        Navigator.of(context).pushReplacementNamed('/login');
+        // Clear navigation stack and go to login
+        Navigator.of(context).pushNamedAndRemoveUntil(
+          '/login',
+          (route) => false,
+        );
       }
     }
   }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <gtk/gtk_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  gtk
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import file_selector_macos
 import firebase_core
 import firebase_messaging
@@ -15,6 +16,7 @@ import sqflite_darwin
 import video_player_avfoundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.35"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -418,6 +450,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   html:
     dependency: transitive
     description:
@@ -583,6 +623,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  mailer:
+    dependency: "direct main"
+    description:
+      name: mailer
+      sha256: c3b934c0e800ddc946167c0123a900eba5acd009abb73648d0191a742542f2b4
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0+1
+version: 1.1.3+1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -36,6 +36,7 @@ dependencies:
   shared_preferences: ^2.2.2
   crypto: ^3.0.3
   http: ^1.1.0
+  mailer: ^6.6.0
   image_picker: ^1.0.7
   path_provider: ^2.1.2
   flutter_dotenv: ^5.1.0
@@ -51,6 +52,7 @@ dependencies:
   cached_network_image: ^3.4.1
   showcaseview: ^5.0.1
   video_player: ^2.8.2
+  app_links: ^6.4.1
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   file_selector_windows
   firebase_core
 )


### PR DESCRIPTION
* feat: implement forgot password and reset password flow

- Add forgot password page with email input
- Add reset password page with token validation and password requirements
- Implement Gmail SMTP email service for sending reset links
- Add deep linking support for password reset (foodrx://reset-password)
- Configure Android and iOS manifests for deep link handling
- Add password reset token generation, validation, and invalidation in MongoDB
- Integrate password reset flow in AuthController
- Add password requirements matching signup flow (min 8 chars, uppercase, lowercase, number, special char)
- Clear session after password reset to force re-login
- Fix navigation stack issues and form clearing bugs

* refactor: update education and profile page navigation

- Replace Container with SizedBox in _SliverAppBarDelegate for better layout management in education_page.dart.
- Modify navigation logic in profile_page.dart to clear the stack when redirecting to the login page, enhancing user experience during logout.

* refactor: improve user re-fetching logic in home page

- Change user variable declaration from final to var for flexibility.
- Re-fetch user data after a delay to ensure validity, especially during logout scenarios.
- Update condition to check user ID before reloading diet plans, enhancing state management and user experience.

* chore: update .gitignore to include new directories

- Added /feature_prd and /migrate-db to .gitignore to prevent tracking of feature and migration files.

* chore: bump version number to 1.1.3+1 in pubspec.yaml